### PR TITLE
Fix TL;DR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![CircleCI](https://circleci.com/gh/bitnami/minideb-extras/tree/master.svg?style=shield)](https://circleci.com/gh/bitnami/minideb-extras/tree/master)
-[![Docker Hub Automated Build](http://container.checkforupdates.com/badges/bitnami/minideb-extras)](https://hub.docker.com/r/bitnami/minideb-extras/)
+[![CircleCI](https://circleci.com/gh/bitnami/minideb-extras/tree/master.svg?style=shield)](https://circleci.com/gh/bitnami/minideb-extras-base/tree/master)
+[![Docker Hub Automated Build](http://container.checkforupdates.com/badges/bitnami/minideb-extras)](https://hub.docker.com/r/bitnami/minideb-extras-base/)
 
 # Base Image for bash-based containers
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![CircleCI](https://circleci.com/gh/bitnami/minideb-extras/tree/master.svg?style=shield)](https://circleci.com/gh/bitnami/minideb-extras-base/tree/master)
-[![Docker Hub Automated Build](http://container.checkforupdates.com/badges/bitnami/minideb-extras)](https://hub.docker.com/r/bitnami/minideb-extras-base/)
+[![CircleCI](https://circleci.com/gh/bitnami/minideb-extras-base/tree/master.svg?style=shield)](https://circleci.com/gh/bitnami/minideb-extras-base/tree/master)
+[![Docker Hub Automated Build](http://container.checkforupdates.com/badges/bitnami/minideb-extras-base)](https://hub.docker.com/r/bitnami/minideb-extras-base/)
 
 # Base Image for bash-based containers
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## TL;DR
 
 ```dockerfile
-FROM bitnami/minideb-extras-base:strech
+FROM bitnami/minideb-extras-base:stretch
 ```
 
 ## About


### PR DESCRIPTION
The tag specified in the TL;DR section doesn't exist, so the image can't be used as specified. It should read `stretch` instead of `strech`.