### PR TITLE
Unpack when dir name differs from component name

### DIFF
--- a/stretch/rootfs/libcomponent.sh
+++ b/stretch/rootfs/libcomponent.sh
@@ -59,6 +59,6 @@ component_unpack() {
         echo "Verifying package integrity"
         echo "$package_sha256  ${base_name}.tar.gz" | sha256sum --check -
     fi
-    tar --directory /opt/bitnami --extract --gunzip --file "${base_name}.tar.gz" --no-same-owner --strip-components=2 "${base_name}/files/${name}"
+    tar --directory /opt/bitnami --extract --gunzip --file "${base_name}.tar.gz" --no-same-owner --strip-components=2 "${base_name}/files/"
     rm "${base_name}.tar.gz"
 }


### PR DESCRIPTION
`component_unpack` was looking for files under `${base_name}/files/${name}`, but there are some components that don't follow the same format. For example, node components exist under `${base_name}/files/node` instead of `${base_name}/files/${name}`, or conda components are available under `${base_name}/files/miniconda`.

This pull request fixes that by extracting the files no matter the name of the folder.

The change has been tested successfully with `mariadb`, that has its files under `files/mariadb`; and with `pytorch`, that lives under `files/miniconda`.