### PR TITLE
Fix log() method - liblog.sh

### DIFF
--- a/stretch/rootfs/liblog.sh
+++ b/stretch/rootfs/liblog.sh
@@ -31,7 +31,7 @@ stderr_print() {
 #   None
 #########################
 log() {
-    stderr_print "${NAMI_DEBUG:+${CYAN}${MODULE} ${MAGENTA}$(date "+%T.%2N ")}${RESET}${*}"
+    stderr_print "${BITNAMI_DEBUG:+${CYAN}${MODULE:-} ${MAGENTA}$(date "+%T.%2N ")}${RESET}${*}"
 }
 ########################
 # Log an 'info' message


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

## Description of the change

This PR fixes the `log()` method available at **liblog.sh** library by:

- Ensuring the env. variable **BITNAMI_DEBUG** is used instead of **NAMI_DEBUG**.
- Setting an empty value when the env. variable **MODULE** is not set.