### PR TITLE
Add debug_execute

### DIFF
--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -6,7 +6,7 @@ ENV IMAGE_OS=debian-9
 RUN mkdir --parents /opt/bitnami
 RUN install_packages ca-certificates curl procps
 
-ENV BITNAMI_IMAGE_VERSION=stretch-r255
+ENV BITNAMI_IMAGE_VERSION=stretch-r256
 
 COPY rootfs /
 

--- a/stretch/rootfs/libos.sh
+++ b/stretch/rootfs/libos.sh
@@ -90,3 +90,20 @@ am_i_root() {
 get_total_memory() {
     echo $(($(grep MemTotal /proc/meminfo | awk '{print $2}') / 1024))
 }
+
+#########################
+# Redirects output to /dev/null if debug mode is disabled
+# Globals:
+#   BITNAMI_DEBUG
+# Arguments:
+#   $@ - Command to execute
+# Returns:
+#   None
+#########################
+debug_execute() {
+    if ${BITNAMI_DEBUG:-false}; then
+        "$@"
+    else
+        "$@" >/dev/null 2>&1
+    fi
+}


### PR DESCRIPTION
Add a function `debug_execute` that redirects the output of a command to `/dev/null` if `BITNAMI_DEBUG` is not set to true.