### PR TITLE
Fix 'libfs.sh' by loading 'liblog.sh' from the right path

### DIFF
--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -6,7 +6,7 @@ ENV IMAGE_OS=debian-9
 RUN mkdir --parents /opt/bitnami
 RUN install_packages ca-certificates curl procps
 
-ENV BITNAMI_IMAGE_VERSION=stretch-r263
+ENV BITNAMI_IMAGE_VERSION=stretch-r264
 
 COPY rootfs /
 

--- a/stretch/rootfs/libfs.sh
+++ b/stretch/rootfs/libfs.sh
@@ -3,7 +3,7 @@
 # Library for file system actions
 
 # Load Generic Libraries
-. ./liblog.sh
+. /liblog.sh
 
 # Functions
 


### PR DESCRIPTION
This PR fixes 'libfs.sh' by loading 'liblog.sh' from the right path.