### PR TITLE
Hide unwanted log entry generated by group_exists

### DIFF
--- a/stretch/rootfs/libos.sh
+++ b/stretch/rootfs/libos.sh
@@ -25,7 +25,7 @@ user_exists() {
 #########################
 group_exists() {
     local group="${1:?group is missing}"
-    getent group "$group"
+    getent group "$group" >/dev/null 2>&1
 }
 
 ########################


### PR DESCRIPTION
The `group_exists` function is not hiding the output it generates, and therefore things such as the following happen:

```bash
$ group_exists myuser && echo hello
myuser:x:1000:myuser
hello
```

With this PR, `group_exists` will not throw any output (which is OK, since we're only interested in the exit code).